### PR TITLE
Add basic CI pipeline to run tests in GH actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,52 @@
+name: Rust
+
+on:
+  push:
+    branches:
+    - main
+    - feature/ci
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-core:
+    name: Build + Test Core
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: core
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
+
+    - name: Set up cargo cache
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-
+
+    - name: Build
+      run: cargo build
+
+    - name: Run tests
+      run: cargo test
+      # TODO: Remove once tests are stable
+      continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# git-notify
+# git-notify [![CI](https://github.com/goatfryed/git-notify/actions/workflows/CI.yml/badge.svg)](https://github.com/goatfryed/git-notify/actions/workflows/CI.yml)
 Find out, when your most relevant files change. once.
 
 # Project goals

--- a/core/README.md
+++ b/core/README.md
@@ -1,2 +1,14 @@
 # git-notify cli
 the cli to integrate with git
+
+## Build from source
+
+```sh
+cargo build --release
+# binary will be at: target/release/git-notify
+```
+
+## Tests
+```sh
+cargo test
+```


### PR DESCRIPTION
This just adds a CI workflow that builds the project in GH actions (and runs the tests). As the tests are currently failing, they have set `continue-on-error: true`. This should be removed, once the tests are stable.

Barely touches #12 (some parts of this workflow can be re-used for that).